### PR TITLE
chore: add `husky` in dev dependencies to fix `npm i` not working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "@commitlint/cli": "^18.6.0",
-        "@commitlint/config-conventional": "^18.6.0"
+        "@commitlint/config-conventional": "^18.6.0",
+        "husky": "^9.0.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1173,6 +1174,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.10.tgz",
+      "integrity": "sha512-TQGNknoiy6bURzIO77pPRu+XHi6zI7T93rX+QnJsoYFf3xdjKOur+IlfqzJGMHIK/wXrLg+GsvMs8Op7vI2jVA==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^18.6.0",
-    "@commitlint/config-conventional": "^18.6.0"
+    "@commitlint/config-conventional": "^18.6.0",
+    "husky": "^9.0.10"
   }
 }


### PR DESCRIPTION
add `husky` as one of the `devDependencies` to fix failed `prepare` script as `husky` is not found on `npm install`