### PR TITLE
ci: remove unnecessary dependencies on Commitlint CI

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,14 +11,8 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
 
-      - name: Install commitlint and its dependencies
-        run: |
-          npm install \
-            @commitlint/config-conventional@latest \
-            conventional-changelog-atom@latest \
-            conventional-changelog-conventionalcommits@latest \
-            commitlint@latest
+      - name: Install Conventional Commit configuration for Commitlint
+        run: npm install @commitlint/config-conventional
 
       - name: Validate PR commits with commitlint
-        if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
Remove:
* `conventional-changelog-atom@latest`
* `conventional-changelog-conventionalcommits@latest`
* `commitlint@latest`